### PR TITLE
feat: Split traits into `BlobStore` & `BlobStoreRead`, and expose `redb::Tables` and `redb::Snapshot`

### DIFF
--- a/src/geom.rs
+++ b/src/geom.rs
@@ -15,10 +15,10 @@ use zerocopy::{AsBytes, FromBytes};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryRange<T> {
-    // min is inclusive
-    min: T,
-    // max is exclusive, None means unbounded
-    max: Option<T>,
+    /// min is inclusive
+    pub min: T,
+    /// max is exclusive, None means unbounded
+    pub max: Option<T>,
 }
 
 impl<T> From<std::ops::Range<T>> for QueryRange<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,14 +377,18 @@ pub trait NodeStore<P: TreeParams>: store::BlobStore {
         let id = Node(self.create(data.as_slice())?, PhantomData);
         Ok(IdAndData::new(id, data))
     }
+}
 
+impl<T: store::BlobStore, P: TreeParams> NodeStore<P> for T {}
+
+pub trait NodeStoreRead<P: TreeParams>: store::BlobStoreRead {
     fn data(&self, id: Node<P>) -> Result<OwnedNodeData<P>> {
-        let data = store::BlobStore::read(self, id.0)?;
+        let data = store::BlobStoreRead::read(self, id.0)?;
         Ok(OwnedNodeData::new(data))
     }
 
     fn peek_data<T>(&self, id: Node<P>, f: impl Fn(&NodeData<P>) -> T) -> Result<T> {
-        store::BlobStore::peek(self, id.0, |data| f(NodeData::ref_cast(data)))
+        store::BlobStoreRead::peek(self, id.0, |data| f(NodeData::ref_cast(data)))
     }
 
     fn peek_data_opt<T>(&self, id: Node<P>, f: impl Fn(&NodeData<P>) -> T) -> Result<Option<T>> {
@@ -427,7 +431,7 @@ pub trait NodeStore<P: TreeParams>: store::BlobStore {
     }
 }
 
-impl<T: store::BlobStore, P: TreeParams> NodeStore<P> for T {}
+impl<T: store::BlobStoreRead, P: TreeParams> NodeStoreRead<P> for T {}
 
 #[derive(Debug, Clone, Copy)]
 pub struct SplitOpts {
@@ -515,7 +519,7 @@ impl<P: TreeParams> Node<P> {
         }
     }
 
-    pub fn count(&self, store: &impl NodeStore<P>) -> Result<u64> {
+    pub fn count(&self, store: &impl NodeStoreRead<P>) -> Result<u64> {
         Ok(if let Some(data) = store.data_opt(*self)? {
             1 + data.left().count(store)? + data.right().count(store)?
         } else {
@@ -630,7 +634,7 @@ impl<P: TreeParams> Node<P> {
 
     pub fn assert_invariants(
         &self,
-        store: &impl NodeStore<P>,
+        store: &impl NodeStoreRead<P>,
         include_summary: bool,
     ) -> Result<()> {
         if !self.is_empty() {
@@ -640,14 +644,14 @@ impl<P: TreeParams> Node<P> {
         Ok(())
     }
 
-    pub fn get(&self, key: &PointRef<P>, store: &impl NodeStore<P>) -> Result<Option<P::V>> {
+    pub fn get(&self, key: &PointRef<P>, store: &impl NodeStoreRead<P>) -> Result<Option<P::V>> {
         Ok(self.get0(key, store)?.map(|x| x.value().clone()))
     }
 
     fn get0(
         &self,
         key: &PointRef<P>,
-        store: &impl NodeStore<P>,
+        store: &impl NodeStoreRead<P>,
     ) -> Result<Option<OwnedNodeData<P>>> {
         if let Some(data) = store.data_opt(*self)? {
             match key.cmp_at_rank(data.key(), data.rank()) {
@@ -672,11 +676,11 @@ impl<P: TreeParams> Node<P> {
         }
     }
 
-    pub fn dump(&self, store: &impl NodeStore<P>) -> Result<()> {
+    pub fn dump(&self, store: &impl NodeStoreRead<P>) -> Result<()> {
         self.dump0("".into(), store)
     }
 
-    fn dump0(&self, prefix: String, store: &impl NodeStore<P>) -> Result<()> {
+    fn dump0(&self, prefix: String, store: &impl NodeStoreRead<P>) -> Result<()> {
         if let Some(data) = store.data_opt(*self)? {
             data.left().dump0(format!("{}  ", prefix), store)?;
             println!(
@@ -747,7 +751,7 @@ impl<P: TreeParams> Node<P> {
 
     pub fn iter<'a>(
         &'a self,
-        store: &'a impl NodeStore<P>,
+        store: &'a impl NodeStoreRead<P>,
     ) -> impl Iterator<Item = Result<(Point<P>, P::V)>> + 'a {
         self.iter_impl(
             &|data, _| (data.key().to_owned(), data.value().clone()),
@@ -757,13 +761,13 @@ impl<P: TreeParams> Node<P> {
 
     pub fn values<'a>(
         &'a self,
-        store: &'a impl NodeStore<P>,
+        store: &'a impl NodeStoreRead<P>,
     ) -> impl Iterator<Item = Result<P::V>> + 'a {
         self.iter_impl(&|data, _| data.value().clone(), store)
     }
 
     /// Computes the average depth of the nodes in the tree, as a measure of the tree's balance.
-    pub fn average_node_depth(&self, store: &impl NodeStore<P>) -> Result<(u64, u64)> {
+    pub fn average_node_depth(&self, store: &impl NodeStoreRead<P>) -> Result<(u64, u64)> {
         let mut sum = 0;
         for item in self.iter_impl(&|_, depth| depth, store) {
             sum += item?;
@@ -779,7 +783,7 @@ impl<P: TreeParams> Node<P> {
     fn iter_impl<'a, T: 'a>(
         &'a self,
         project: &'a impl Fn(&NodeData<P>, u64) -> T,
-        store: &'a impl NodeStore<P>,
+        store: &'a impl NodeStoreRead<P>,
     ) -> impl Iterator<Item = Result<T>> + 'a {
         Gen::new(|co| async move {
             if let Err(cause) = self.iter_rec(0, &project, store, &co).await {
@@ -793,7 +797,7 @@ impl<P: TreeParams> Node<P> {
         &self,
         depth: u64,
         project: &impl Fn(&NodeData<P>, u64) -> T,
-        store: &impl NodeStore<P>,
+        store: &impl NodeStoreRead<P>,
         co: &Co<Result<T>>,
     ) -> Result<()> {
         if self.is_empty() {
@@ -817,7 +821,7 @@ impl<P: TreeParams> Node<P> {
     pub fn range_summary(
         &self,
         query: &QueryRange3d<P>,
-        store: &impl NodeStore<P>,
+        store: &impl NodeStoreRead<P>,
     ) -> Result<P::M> {
         let bbox = BBoxRef::all();
         self.range_summary_rec(query, &bbox, store)
@@ -827,7 +831,7 @@ impl<P: TreeParams> Node<P> {
         &self,
         query: &QueryRange3d<P>,
         bbox: &BBoxRef<P>,
-        store: &impl NodeStore<P>,
+        store: &impl NodeStoreRead<P>,
     ) -> Result<P::M> {
         if self.is_empty() {
             return Ok(P::M::neutral());
@@ -864,7 +868,11 @@ impl<P: TreeParams> Node<P> {
     }
 
     /// Count the number of elements in a 3d range.
-    pub fn range_count(&self, query: &QueryRange3d<P>, store: &impl NodeStore<P>) -> Result<u64> {
+    pub fn range_count(
+        &self,
+        query: &QueryRange3d<P>,
+        store: &impl NodeStoreRead<P>,
+    ) -> Result<u64> {
         let bbox = BBoxRef::all();
         self.range_count_rec(query, &bbox, store)
     }
@@ -873,7 +881,7 @@ impl<P: TreeParams> Node<P> {
         &self,
         query: &QueryRange3d<P>,
         bbox: &BBoxRef<P>,
-        store: &impl NodeStore<P>,
+        store: &impl NodeStoreRead<P>,
     ) -> Result<u64> {
         if self.is_empty() {
             return Ok(0);
@@ -885,7 +893,7 @@ impl<P: TreeParams> Node<P> {
         &'a self,
         query: QueryRange3d<P>,
         split_factor: u64,
-        store: &'a impl NodeStore<P>,
+        store: &'a impl NodeStoreRead<P>,
     ) -> impl Iterator<Item = Result<(QueryRange3d<P>, u64)>> + 'a
     where
         P::X: Display,
@@ -913,7 +921,7 @@ impl<P: TreeParams> Node<P> {
     pub fn find_split_plane_supernew(
         &self,
         query: &QueryRange3d<P>,
-        store: &impl NodeStore<P>,
+        store: &impl NodeStoreRead<P>,
     ) -> Result<Option<(QueryRange3d<P>, Node<P>, QueryRange3d<P>, Node<P>)>> {
         if self.is_empty() {
             return Ok(None);
@@ -948,7 +956,7 @@ impl<P: TreeParams> Node<P> {
         &self,
         query: &QueryRange3d<P>,
         count: u64,
-        store: &impl NodeStore<P>,
+        store: &impl NodeStoreRead<P>,
     ) -> Result<Option<(QueryRange3d<P>, u64, QueryRange3d<P>, u64)>> {
         let bbox = BBoxRef::all();
         self.find_split_plane_rec(*self, query, count, &bbox, store)
@@ -958,7 +966,7 @@ impl<P: TreeParams> Node<P> {
         &self,
         query: &QueryRange3d<P>,
         count: u64,
-        store: &impl NodeStore<P>,
+        store: &impl NodeStoreRead<P>,
     ) -> Result<Option<(QueryRange3d<P>, u64, QueryRange3d<P>, u64)>> {
         let Some((point, order)) = self.find_split_plane_2(query, store)? else {
             return Ok(None);
@@ -973,7 +981,7 @@ impl<P: TreeParams> Node<P> {
     pub fn find_split_plane_2(
         &self,
         query: &QueryRange3d<P>,
-        store: &impl NodeStore<P>,
+        store: &impl NodeStoreRead<P>,
     ) -> Result<Option<(Point<P>, SortOrder)>> {
         let mut points = self.query_interleaved(query, &|_, data| data.key().to_owned(), store);
         let Some(a) = points.next() else {
@@ -1021,7 +1029,7 @@ impl<P: TreeParams> Node<P> {
         query: &QueryRange3d<P>,
         count: u64,
         bbox: &BBoxRef<P>,
-        store: &impl NodeStore<P>,
+        store: &impl NodeStoreRead<P>,
     ) -> Result<Option<(QueryRange3d<P>, u64, QueryRange3d<P>, u64)>> {
         if self.is_empty() {
             return Ok(None);
@@ -1073,7 +1081,7 @@ impl<P: TreeParams> Node<P> {
         count: u64,
         split_factor: u64,
         co: &Co<Result<(QueryRange3d<P>, u64)>>,
-        store: &impl NodeStore<P>,
+        store: &impl NodeStoreRead<P>,
     ) -> Result<()> {
         // we split the query, but not the tree
         let root = self;
@@ -1102,7 +1110,7 @@ impl<P: TreeParams> Node<P> {
     pub fn query<'a>(
         &'a self,
         query: &'a QueryRange3d<P>,
-        store: &'a impl NodeStore<P>,
+        store: &'a impl NodeStoreRead<P>,
     ) -> impl Iterator<Item = Result<(Point<P>, P::V)>> + 'a {
         let project = |_, data: &NodeData<P>| (data.key().to_owned(), data.value().clone());
         Gen::new(|co| async move {
@@ -1126,7 +1134,7 @@ impl<P: TreeParams> Node<P> {
         &self,
         query: &QueryRange3d<P>,
         project: &impl Fn(Node<P>, &NodeData<P>) -> T,
-        store: &impl NodeStore<P>,
+        store: &impl NodeStoreRead<P>,
         co: &Co<Result<T>>,
     ) -> Result<()> {
         if self.is_empty() {
@@ -1166,7 +1174,7 @@ impl<P: TreeParams> Node<P> {
         self,
         query: &'a QueryRange3d<P>,
         ordering: SortOrder,
-        store: &'a impl NodeStore<P>,
+        store: &'a impl NodeStoreRead<P>,
     ) -> impl Iterator<Item = Result<(Point<P>, P::V)>> + 'a {
         Gen::new(|co| async move {
             if let Err(cause) = self.query_ordered_rec(query, ordering, store, &co).await {
@@ -1180,7 +1188,7 @@ impl<P: TreeParams> Node<P> {
         &self,
         query: &QueryRange3d<P>,
         ordering: SortOrder,
-        store: &impl NodeStore<P>,
+        store: &impl NodeStoreRead<P>,
         co: &Co<Result<(Point<P>, P::V)>>,
     ) -> Result<()> {
         if self.is_empty() {
@@ -1246,7 +1254,7 @@ impl<P: TreeParams> Node<P> {
         self,
         query: &'a QueryRange3d<P>,
         project: &'a impl Fn(Node<P>, &NodeData<P>) -> T,
-        store: &'a impl NodeStore<P>,
+        store: &'a impl NodeStoreRead<P>,
     ) -> Box<dyn Iterator<Item = Result<T>> + 'a> {
         match self.query_interleaved_rec(query, project, store) {
             Ok(iter) => Box::new(iter),
@@ -1258,7 +1266,7 @@ impl<P: TreeParams> Node<P> {
         self,
         query: &'a QueryRange3d<P>,
         project: &'a impl Fn(Node<P>, &NodeData<P>) -> T,
-        store: &'a impl NodeStore<P>,
+        store: &'a impl NodeStoreRead<P>,
     ) -> Result<impl Iterator<Item = Result<T>> + 'a> {
         let res = if self.is_empty() {
             None
@@ -1314,7 +1322,7 @@ fn range_count<P: TreeParams>(
     data: &NodeData<P>,
     bbox: &BBoxRef<P>,
     query: &QueryRange3d<P>,
-    store: &impl NodeStore<P>,
+    store: &impl NodeStoreRead<P>,
 ) -> Result<u64> {
     if bbox.contained_in(&query) {
         Ok(data.count())
@@ -1514,7 +1522,7 @@ impl<P: TreeParams> NodeData<P> {
 
     pub fn assert_invariants(
         &self,
-        store: &impl NodeStore<P>,
+        store: &impl NodeStoreRead<P>,
         include_summary: bool,
     ) -> Result<AssertInvariantsRes<P>> {
         let left = store.data_opt(self.left())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ mod layout;
 mod blob_seq;
 mod fmt;
 use layout::*;
-pub use store::{mem::MemStore, BlobStore, NodeId};
+pub use store::{mem::MemStore, BlobStore, BlobStoreRead, NodeId};
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 pub use blob_seq::{BlobSeq, BlobSeqRef};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,6 +468,12 @@ impl<P: TreeParams> From<store::NodeId> for Node<P> {
     }
 }
 
+impl<P: TreeParams> From<Node<P>> for store::NodeId {
+    fn from(id: Node<P>) -> Self {
+        store::NodeId::from(id.0)
+    }
+}
+
 impl<P: TreeParams> Clone for Node<P> {
     fn clone(&self) -> Self {
         Self(self.0, PhantomData)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ pub use store::{mem::MemStore, BlobStore, NodeId};
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 pub use blob_seq::{BlobSeq, BlobSeqRef};
-pub use store::redb::RedbBlobStore;
+pub use store::redb::{RedbBlobStore, Snapshot, Tables};
 
 #[cfg(any(test, feature = "mock-willow"))]
 pub mod mock_willow;

--- a/src/store.rs
+++ b/src/store.rs
@@ -17,7 +17,9 @@ pub trait BlobStore: BlobStoreRead {
 /// A simple store trait for reading blobs.
 pub trait BlobStoreRead {
     /// Read a node from the store.
-    fn read(&self, id: NodeId) -> Result<Vec<u8>>;
+    fn read(&self, id: NodeId) -> Result<Vec<u8>> {
+        self.peek(id, |x| x.to_vec())
+    }
     /// Peek at a node in the store and project it into a value.
     fn peek<T>(&self, id: NodeId, f: impl Fn(&[u8]) -> T) -> Result<T>;
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -4,18 +4,22 @@ use zerocopy::{AsBytes, FromBytes, FromZeroes};
 pub mod mem;
 pub mod redb;
 
-/// A simple store trait for storing blobs.
-pub trait BlobStore {
+/// A simple store trait for reading & storing blobs.
+pub trait BlobStore: BlobStoreRead {
     /// Create a new node in the store. The generated ids should not be reused.
     fn create(&mut self, node: &[u8]) -> Result<NodeId>;
-    /// Read a node from the store.
-    fn read(&self, id: NodeId) -> Result<Vec<u8>>;
-    /// Peek at a node in the store and project it into a value.
-    fn peek<T>(&self, id: NodeId, f: impl Fn(&[u8]) -> T) -> Result<T>;
     /// Update a node in the store.
     fn update(&mut self, id: NodeId, node: &[u8]) -> Result<()>;
     /// Delete a node from the store.
     fn delete(&mut self, id: NodeId) -> Result<()>;
+}
+
+/// A simple store trait for reading blobs.
+pub trait BlobStoreRead {
+    /// Read a node from the store.
+    fn read(&self, id: NodeId) -> Result<Vec<u8>>;
+    /// Peek at a node in the store and project it into a value.
+    fn peek<T>(&self, id: NodeId, f: impl Fn(&[u8]) -> T) -> Result<T>;
 }
 
 /// We implement the zero copy traits with native u64. This means that the storage

--- a/src/store/mem.rs
+++ b/src/store/mem.rs
@@ -52,14 +52,6 @@ impl BlobStore for MemStore {
 }
 
 impl BlobStoreRead for MemStore {
-    fn read(&self, id: NodeId) -> Result<Vec<u8>> {
-        assert!(!id.is_empty());
-        match self.nodes.get(&id) {
-            Some(data) => Ok(data.to_vec()),
-            None => Err(anyhow::anyhow!("Node not found")),
-        }
-    }
-
     fn peek<T>(&self, id: NodeId, f: impl Fn(&[u8]) -> T) -> Result<T> {
         assert!(!id.is_empty());
         match self.nodes.get(&id) {

--- a/src/store/mem.rs
+++ b/src/store/mem.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use super::{BlobStore, NodeId, Result};
+use super::{BlobStore, BlobStoreRead, NodeId, Result};
 
 #[derive(Debug, Clone)]
 pub struct MemStore {
@@ -44,6 +44,14 @@ impl BlobStore for MemStore {
         Ok(())
     }
 
+    fn delete(&mut self, id: NodeId) -> Result<()> {
+        assert!(!id.is_empty());
+        self.nodes.remove(&id);
+        Ok(())
+    }
+}
+
+impl BlobStoreRead for MemStore {
     fn read(&self, id: NodeId) -> Result<Vec<u8>> {
         assert!(!id.is_empty());
         match self.nodes.get(&id) {
@@ -58,11 +66,5 @@ impl BlobStore for MemStore {
             Some(data) => Ok(f(data)),
             None => Err(anyhow::anyhow!("Node not found")),
         }
-    }
-
-    fn delete(&mut self, id: NodeId) -> Result<()> {
-        assert!(!id.is_empty());
-        self.nodes.remove(&id);
-        Ok(())
     }
 }

--- a/src/store/redb.rs
+++ b/src/store/redb.rs
@@ -1,4 +1,7 @@
-use redb::{Database, ReadableTable, ReadableTableMetadata, TableDefinition, WriteTransaction};
+use redb::{
+    Database, ReadTransaction, ReadableTable, ReadableTableMetadata, TableDefinition,
+    WriteTransaction,
+};
 use zerocopy::{AsBytes, FromBytes};
 
 use super::{BlobStore, NodeId, Result};
@@ -62,8 +65,7 @@ impl RedbBlobStore {
 
     fn create_tables(db: &redb::Database) -> Result<()> {
         let txn = db.begin_write()?;
-        txn.open_table(AUTOINC_TABLE)?;
-        txn.open_table(BLOB_TABLE)?;
+        Tables::open(&txn)?;
         txn.commit()?;
         Ok(())
     }
@@ -99,6 +101,14 @@ pub struct Snapshot {
     blob_table: redb::ReadOnlyTable<NodeId, &'static [u8]>,
 }
 
+impl Snapshot {
+    pub fn open(txn: &ReadTransaction) -> Result<Self> {
+        Ok(Self {
+            blob_table: txn.open_table(BLOB_TABLE)?,
+        })
+    }
+}
+
 impl BlobStore for Snapshot {
     fn read(&self, id: NodeId) -> Result<Vec<u8>> {
         self.peek(id, |x| x.to_vec())
@@ -124,9 +134,57 @@ impl BlobStore for Snapshot {
     }
 }
 
-struct Tables<'a> {
+pub struct Tables<'a> {
     autoinc: redb::Table<'a, &'static str, u64>,
     blobs: redb::Table<'a, NodeId, &'static [u8]>,
+}
+
+impl<'a> Tables<'a> {
+    pub fn open(txn: &'a WriteTransaction) -> Result<Self> {
+        let autoinc = txn.open_table(AUTOINC_TABLE)?;
+        let blobs = txn.open_table(BLOB_TABLE)?;
+        Ok(Self { autoinc, blobs })
+    }
+}
+
+impl<'a> BlobStore for Tables<'a> {
+    fn create(&mut self, node: &[u8]) -> Result<NodeId> {
+        let current_id = match self.autoinc.get("id")? {
+            Some(id) => id.value(),
+            None => 0u64,
+        };
+        let new_id = current_id + 1;
+        self.autoinc.insert("id", &new_id)?;
+        let new_node_id = NodeId::from(new_id);
+        self.blobs.insert(&new_node_id, node)?;
+        Ok(new_node_id)
+    }
+
+    fn read(&self, id: NodeId) -> Result<Vec<u8>> {
+        let value = self
+            .blobs
+            .get(&id)?
+            .ok_or_else(|| anyhow::anyhow!("Node not found"))?;
+        Ok(value.value().to_vec())
+    }
+
+    fn peek<T>(&self, id: NodeId, f: impl Fn(&[u8]) -> T) -> Result<T> {
+        let value = self
+            .blobs
+            .get(&id)?
+            .ok_or_else(|| anyhow::anyhow!("Node not found"))?;
+        Ok(f(value.value()))
+    }
+
+    fn update(&mut self, id: NodeId, node: &[u8]) -> Result<()> {
+        self.blobs.insert(id, node)?;
+        Ok(())
+    }
+
+    fn delete(&mut self, id: NodeId) -> Result<()> {
+        self.blobs.remove(id)?;
+        Ok(())
+    }
 }
 
 self_cell::self_cell!(
@@ -149,56 +207,27 @@ impl WriteBatch {
 
 impl BlobStore for WriteBatch {
     fn create(&mut self, node: &[u8]) -> Result<NodeId> {
-        let new_node_id = self.0.with_dependent_mut(|_db, tables| {
-            let autoinc_table = &mut tables.autoinc;
-            let current_id = match autoinc_table.get("id")? {
-                Some(id) => id.value(),
-                None => 0u64,
-            };
-            let new_id = current_id + 1;
-            autoinc_table.insert("id", &new_id)?;
-            let new_node_id = NodeId::from(new_id);
-            let blob_table = &mut tables.blobs;
-            blob_table.insert(&new_node_id, node)?;
-            anyhow::Ok(new_node_id)
-        })?;
+        let new_node_id = self
+            .0
+            .with_dependent_mut(|_db, tables| tables.create(node))?;
         Ok(new_node_id)
     }
 
     fn peek<T>(&self, id: NodeId, f: impl Fn(&[u8]) -> T) -> Result<T> {
-        self.0.with_dependent(|_db, tables| {
-            let blob_table = &tables.blobs;
-            match blob_table.get(&id)? {
-                Some(value) => Ok(f(value.value())),
-                None => Err(anyhow::anyhow!("Node not found")),
-            }
-        })
+        self.0.with_dependent(|_db, tables| tables.peek(id, f))
     }
 
     fn read(&self, id: NodeId) -> Result<Vec<u8>> {
-        self.0.with_dependent(|_db, tables| {
-            let blob_table = &tables.blobs;
-            match blob_table.get(&id)? {
-                Some(value) => Ok(value.value().to_vec()),
-                None => Err(anyhow::anyhow!("Node not found")),
-            }
-        })
+        self.0.with_dependent(|_db, tables| tables.read(id))
     }
 
     fn update(&mut self, id: NodeId, node: &[u8]) -> Result<()> {
-        self.0.with_dependent_mut(|_db, tables| {
-            let blob_table = &mut tables.blobs;
-            blob_table.insert(&id, node)?;
-            Ok(())
-        })
+        self.0
+            .with_dependent_mut(|_db, tables| tables.update(id, node))
     }
 
     fn delete(&mut self, id: NodeId) -> Result<()> {
-        self.0.with_dependent_mut(|_db, tables| {
-            let blob_table = &mut tables.blobs;
-            blob_table.remove(&id)?;
-            Ok(())
-        })
+        self.0.with_dependent_mut(|_db, tables| tables.delete(id))
     }
 }
 


### PR DESCRIPTION
Also:
- Expose `QueryRange::{min, max}`, as there was no way to access these outside the crate, but they're returned by APIs like `split_range`.
- Implement `split_range_owned`, a version of `split_range` that side-steps lifetimes. This makes my life much easier.
- Make `BlobStoreRead::read` a default impl that just uses `BlobStoreRead::peek`, just a small code-reuse thing I noticed.
- Make `WriteBatch` and `RedbBlobStore`'s `BlobStore` impl use the `Tables` and `Snapshot` impl also for code reuse.